### PR TITLE
Fixed Eclipse warning from Maven POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,19 @@
 										<ignore></ignore>
 									</action>
 								</pluginExecution>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>org.apache.maven.plugins</groupId>
+										<artifactId>maven-enforcer-plugin</artifactId>
+										<versionRange>[1.0.0,)</versionRange>
+										<goals>
+											<goal>enforce</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore></ignore>
+									</action>
+								</pluginExecution>
 							</pluginExecutions>
 						</lifecycleMappingMetadata>
 					</configuration>


### PR DESCRIPTION
Cleaning up the Eclipse-specific section of the pom.xml file so Eclipse doesn't show warnings when handling the maven-enforcer-plugin from Sonatype OSS.
